### PR TITLE
Allow building from root dir, saves consumers a command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(xwayland-kiosk-helper)
+
+add_subdirectory(xwayland-preload)


### PR DESCRIPTION
Saves consumers adding a "source-dir: xwayland-preload" to their YAML